### PR TITLE
Remove tech stack icons for VS Code, Linux, and GitHub

### DIFF
--- a/README.md
+++ b/README.md
@@ -29,9 +29,6 @@
   <img src="https://www.vectorlogo.zone/logos/python/python-icon.svg" width="60">
   <img src="https://www.vectorlogo.zone/logos/djangoproject/djangoproject-icon.svg" width="60">
   <img src="https://www.vectorlogo.zone/logos/tailwindcss/tailwindcss-icon.svg" width="60">
-  <img src="https://raw.githubusercontent.com/github/explore/80688e429a7d4ef2fca1e82350fe8e3517d3494d/topics/visual-studio-code/visual-studio-code.png" width="60">
-  <img src="https://www.vectorlogo.zone/logos/linux/linux-icon.svg" width="60">
-  <img src="https://www.vectorlogo.zone/logos/github/github-icon.svg" width="60">
 </p>
 
 <!--# My Tech Stack-->


### PR DESCRIPTION
Removed icons for Visual Studio Code, Linux, and GitHub from the tech stack section.